### PR TITLE
SEO: Include word definitions in meta on the detail view.

### DIFF
--- a/app/assets/stylesheets/_cards.css.scss
+++ b/app/assets/stylesheets/_cards.css.scss
@@ -1,6 +1,7 @@
 .card {
   margin: 0;
-  width:32%;
+  width: 32%;
+
   @media (max-width: $screen-md-max) {
     width: 49%;
   }

--- a/app/assets/stylesheets/_words.css.scss
+++ b/app/assets/stylesheets/_words.css.scss
@@ -3,11 +3,33 @@
   text-align: center;
 }
 
-.definition {
+.definition,
+.definition-card {
   .word-text {
     @extend strong;
   }
+
   .part-of-speech {
     font-style: italic;
   }
+}
+
+.definition-card {
+  padding: 8px;
+
+  .well {
+    margin-bottom: 9px;
+    position: relative;
+    @include box-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
+  }
+
+  .definitions-list {
+    .definition-text {
+    }
+  }
+}
+
+.attribution-text {
+  font-size: 85%;
+  padding: 8px;
 }

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -5,8 +5,8 @@ module PagesHelper
   end
 
   def full_page_title
-    "Homophone.com - " +
-      (content_for?(:title) ? content_for(:title) : "Your Complete List of Homophones")
+    tagline = (content_for?(:title) ? content_for(:title) : "Your Complete List of Homophones")
+    "#{tagline} at Homophone.com"
   end
 
   def page_h
@@ -17,7 +17,7 @@ module PagesHelper
     defaults = {
       :class => "btn btn-primary"
     }
-    link_to("Click for more homophones !", browse_path, defaults.merge(options))
+    link_to("More homophones", browse_path, defaults.merge(options))
   end
 
 end

--- a/app/helpers/word_sets_helper.rb
+++ b/app/helpers/word_sets_helper.rb
@@ -1,5 +1,9 @@
 module WordSetsHelper
 
+  def homophones_to_title(word_set)
+    word_set.words_ordered_by_current_query.map(&:display).join(", ")
+  end
+
   def plain_icon(name)
     raw "<span class=\"fa fa-#{name}\"></span>"
   end

--- a/app/helpers/words_helper.rb
+++ b/app/helpers/words_helper.rb
@@ -1,7 +1,7 @@
 module WordsHelper
 
   def word_btn(word)
-    button_tag word.display,
+    link_to word.display, word.word_set,
       :class => "btn word-btn",
       :"data-word-id" => word.id,
       :"data-match-type" => word.describe_match_type,

--- a/app/views/word_sets/_word_set_details.html.erb
+++ b/app/views/word_sets/_word_set_details.html.erb
@@ -1,0 +1,41 @@
+<% @defintion_providers = {} %>
+<div class="row">
+  <% @word_set.words_matches_preceding(@query).each do |word| %>
+    <% @word = word %>
+
+    <div class="col-sm-6">
+      <div class="definition-card">
+        <div class="well">
+          <span class="word-text"><%= @word.text %></span>
+          
+          <% @definitions = @word.get_definitions.limit(4) %>
+
+          <% if @definitions.blank? %>
+            <p>So sorry... We couldn't find a definition for this word.</p>
+          <% else %>
+            <ol class="definitions-list">
+              <% @definitions.each do |definition| %>
+                <li>
+                  :: 
+                  <span class="part-of-speech"><%= definition.part_of_speech %></span>
+                  <p class="definition-text">
+                    <%= definition.text %>
+                    <% @defintion_providers[definition.attribution_text] = true %>
+                  </p>
+                </li>
+              <% end %>
+            </ol>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="col-sm-6">
+    <p class="attribution-text">
+      Definitions 
+      <%= @defintion_providers.keys.join(", ") %> and Wordnik.
+    </p>
+  </div>
+
+</div>

--- a/app/views/word_sets/random.html.erb
+++ b/app/views/word_sets/random.html.erb
@@ -6,7 +6,7 @@
       <%= content_tag page_h, "Some random homophones" %>
     </div>
     <div class="col-sm-3">
-      <%= content_tag page_h, link_to("Click for more random homophones!", random_homophone_path, class: "btn btn-info btn-xs-full") %>
+      <%= content_tag page_h, link_to("More random homophones", random_homophone_path, class: "btn btn-info btn-xs-full") %>
     </div>
   </div>
 

--- a/app/views/word_sets/show.html.erb
+++ b/app/views/word_sets/show.html.erb
@@ -1,27 +1,84 @@
-<%= content_for(:title, @word_set.words_ordered_by_current_query.map(&:display).join(", ")) %>
+<%= content_for(:title, homophones_to_title(@word_set)) %>
+
+<%# TODO: Older / Newer links %>
+<!-- http://getbootstrap.com/components/#pagination-pager -->
 
 <div class="container">
 
   <div class="row">
     <div class="col-sm-9">
-      <%= content_tag page_h, "These words are homophones" %>
+      <%= content_tag page_h, homophones_to_title(@word_set) %>
+      <p class="lead">
+        The words <%= homophones_to_title(@word_set) %>
+        sound the same but have different meanings and definitions.
+        Why do <%= homophones_to_title(@word_set) %>
+        sound the same even though they have completely different spellings?
+      </p>
+      <p>
+        The english language is full of homophones,
+        and these are just a few.
+      </p>
     </div>
     <div class="col-sm-3">
       <%= content_tag page_h, btn_view_more(class: "btn btn-primary btn-xs-full") %>
     </div>
   </div>
 
-  <div class="card-set-container">
-    <%= render partial: "card" %>
+  <%= render partial: "word_sets/word_set_details" %>
 
-    <%= render partial: "ads/card" %>
+  <%= render 'ads/responsive' %>
+
+  <h4>Share <%= content_for(:title) %></h4>
+
+  <div class="list-group" role="menu">
+    <a href="#" class="list-group-item"
+       data-share-button data-id="<%= @word_set.id %>" data-social="facebook">
+      <%= fa_stacked_icon("facebook inverse", base: "square", class: "icon-facebook") %>
+      Facebook
+    </a>
+    <a href="#" class="list-group-item"
+       data-share-button data-id="<%= @word_set.id %>" data-social="twitter">
+      <%= fa_stacked_icon("twitter inverse", base: "square", class: "icon-twitter") %>
+      Twitter
+    </a>
+    <a href="#" class="list-group-item"
+       data-share-button data-id="<%= @word_set.id %>" data-social="email">
+      <%= fa_stacked_icon("envelope inverse", base: "square", class: "icon-email") %>
+      Email
+    </a>
+  </div>
+
+  <% if can? :update, @word_set %>
+    <h4>Admin</h4>
+    <div class="list-group" role="menu">
+      <%= link_to fa_stacked_icon("info inverse", base: "square", class: "icon-success") + " Show", word_set_path(@word_set), class: "list-group-item" -%>
+      <%= link_to fa_stacked_icon("pencil inverse", base: "square", class: "icon-edit") + " Edit", edit_word_set_path(@word_set), class: "list-group-item" -%>
+      <%= link_to fa_stacked_icon("trash-o inverse", base: "square", class: "icon-delete") + " Delete", @word_set, class: "list-group-item", method: :delete, data: { confirm: "Really delete this Word Set?\r\nYou can't undo this!" } -%>
+    </div>
+  <% end %>
+
+  <%= render 'ads/responsive' %>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      About Homophones
+    </div>
+    <div class="panel-body">
+      <p>
+        Homophones (literally "same sound") are usually defined as words that
+        share the same pronunciation, regardless of how they are spelled.
+      </p>
+      <p
+        >If they are spelled the same then they are also homographs (and homonyms);
+        if they are spelled differently then they are also heterographs (literally "different writing").
+        <%= link_to fa_icon("external-link"), "http://en.wikipedia.org/wiki/Homophone", :target => "_blank" %>
+      </p>
+    </div>
   </div>
 
   <div class="row">
     <div class="col-sm-12 text-center">
-      <%= link_to "What is a homophone?", "/about#what", class: "btn btn-info btn-lg btn-xs-full" %>
+      <%= random_btn %>
     </div>
   </div>
-
-  
 </div>


### PR DESCRIPTION
Also don't use the "card" for this view. Instead include definition and details automatically (see below).

![screen shot 2014-12-07 at 10 52 07 am](https://cloud.githubusercontent.com/assets/4197823/5331575/1a94d108-7dff-11e4-96f7-12767109915a.png)
