### PR TITLE
Bug: request.referer may be invalid for URI

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < ApplicationController
 
     if @user && @user.authenticate(params[:password])
       session[:user_id] = @user.id
-      redirect_to session.delete(:return_to), info: "Welcome back!"
+      redirect_to initial_path, info: "Welcome back!"
     else
       render action: 'new', warning: "Email or password invalid."
     end
@@ -20,6 +20,12 @@ class SessionsController < ApplicationController
   def destroy
     session[:user_id] = nil
     redirect_to request.referer, info: "You're logged out."
+  end
+
+  private
+
+  def initial_path
+    session.delete(:return_to) || root_path
   end
 
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,9 @@
 class SessionsController < ApplicationController
-  
+
   def new
-    session[:return_to] = request.referer unless URI(request.referer).path == current_path
+    if request.referer && URI(request.referer).path != current_path
+      session[:return_to] = request.referer
+    end
   end
 
   def create
@@ -19,6 +21,5 @@ class SessionsController < ApplicationController
     session[:user_id] = nil
     redirect_to request.referer, info: "You're logged out."
   end
-
 
 end

--- a/spec/controllers/sessions_spec.rb
+++ b/spec/controllers/sessions_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe SessionsController do
+  describe "GET new" do
+    it "works when there is no referer" do
+      get :new
+      expect(response).to render_template("sessions/new")
+    end
+  end
+
+  describe "POST create" do
+    let(:email) { "user@example.com" }
+    let(:password) { "whatever123" }
+
+    let(:params) { {
+      :email => email,
+      :password => password
+    } }
+    let(:user) { User.create(params) }
+
+    before do
+      user
+      post(:create, params)
+    end
+
+    context "when session[:return_to] is nil" do
+      it "redirects to root_path" do
+        assert_response_redirect(response, root_path)
+      end
+    end
+
+    context "when session[:return_to] is a URI" do
+      it "redirects to session[:return_to]" do
+        skip "TODO"
+      end
+    end
+  end
+
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,8 +1,0 @@
-require "spec_helper.rb"
-
-describe "/sessions/new" do
-  it "works when there is no referer" do
-    get "/sessions/new"
-    expect(response).to render_template("sessions/new")
-  end
-end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,8 @@
+require "spec_helper.rb"
+
+describe "/sessions/new" do
+  it "works when there is no referer" do
+    get "/sessions/new"
+    expect(response).to render_template("sessions/new")
+  end
+end


### PR DESCRIPTION
```
Completed 500 Internal Server Error in 1ms
2014-12-23T03:29:56.679006+00:00 app[web.1]: Processing by SessionsController#new as HTML
2014-12-23T03:29:56.681625+00:00 app[web.1]: 
2014-12-23T03:29:56.681628+00:00 app[web.1]: ArgumentError (bad argument (expected URI object or URI string)):
2014-12-23T03:29:56.681630+00:00 app[web.1]:   app/controllers/sessions_controller.rb:4:in `new'
```

```
  def new
    session[:return_to] = request.referer unless URI(request.referer).path == current_path
  end
```